### PR TITLE
Allow the Google Cloud Client Library to source authentication settings from the environment

### DIFF
--- a/lib/active_model/datastore/connection.rb
+++ b/lib/active_model/datastore/connection.rb
@@ -24,13 +24,10 @@ module CloudDatastore
       ENV['GCLOUD_KEYFILE_JSON'] = '{"private_key": "' + ENV['SERVICE_ACCOUNT_PRIVATE_KEY'] + '",
       "client_email": "' + ENV['SERVICE_ACCOUNT_CLIENT_EMAIL'] + '"}'
     end
-  else
-    ENV['DATASTORE_EMULATOR_HOST'] = 'localhost:8181'
-    ENV['GCLOUD_PROJECT'] = 'test-datastore'
   end
 
   def self.dataset
-    @dataset ||= Google::Cloud.datastore(ENV['GCLOUD_PROJECT'])
+    @dataset ||= Google::Cloud.datastore
   end
 
   def self.reset_dataset

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -54,6 +54,10 @@ class ActiveSupport::TestCase
       system("cloud_datastore_emulator start --port=8181 --testing #{data_dir} &")
       sleep 3
     end
+    if defined?(Rails) != 'constant'
+      ENV['DATASTORE_EMULATOR_HOST'] = 'localhost:8181'
+      ENV['GCLOUD_PROJECT'] = 'test-datastore'
+    end
     CloudDatastore.dataset
     CarrierWave.configure do |config|
       config.reset_config


### PR DESCRIPTION
Resolves #8.

Note that I am not using Rails, so I have not modified the code which modifies the environment under Rails.