### PR TITLE
Add namespace support

### DIFF
--- a/test/cases/callbacks_test.rb
+++ b/test/cases/callbacks_test.rb
@@ -5,6 +5,7 @@ class CallbacksTest < ActiveSupport::TestCase
     super
     @mock_model = MockModel.new
     @mock_model.name = 'Initial Name'
+    @mock_model.namespace = nil
   end
 
   test 'before validation callback on save' do
@@ -13,7 +14,7 @@ class CallbacksTest < ActiveSupport::TestCase
     end
     refute @mock_model.save
     assert_nil @mock_model.name
-    assert_equal 0, MockModel.count_test_entities
+    assert_equal 0, MockModel.count_test_entities(namespace: @mock_model.namespace)
   end
 
   test 'after validation callback on save' do
@@ -22,7 +23,7 @@ class CallbacksTest < ActiveSupport::TestCase
     end
     assert @mock_model.save
     assert_nil @mock_model.name
-    assert_equal 1, MockModel.count_test_entities
+    assert_equal 1, MockModel.count_test_entities(namespace: @mock_model.namespace)
   end
 
   test 'before save callback' do
@@ -31,7 +32,8 @@ class CallbacksTest < ActiveSupport::TestCase
     end
     assert @mock_model.save
     assert_equal 'Name changed before save', @mock_model.name
-    assert_equal 'Name changed before save', MockModel.all.first.name
+    ns = @mock_model.namespace
+    assert_equal 'Name changed before save', MockModel.all(namespace: ns).first.name
   end
 
   test 'after save callback' do
@@ -40,7 +42,8 @@ class CallbacksTest < ActiveSupport::TestCase
     end
     assert @mock_model.save
     assert_equal 'Name changed after save', @mock_model.name
-    assert_equal 'Initial Name', MockModel.all.first.name
+    ns = @mock_model.namespace
+    assert_equal 'Initial Name', MockModel.all(namespace: ns).first.name
   end
 
   test 'before validation callback on update' do
@@ -65,7 +68,8 @@ class CallbacksTest < ActiveSupport::TestCase
     end
     assert @mock_model.update(name: 'This name should get changed')
     assert_equal 'Name changed before update', @mock_model.name
-    assert_equal 'Name changed before update', MockModel.all.first.name
+    ns = @mock_model.namespace
+    assert_equal 'Name changed before update', MockModel.all(namespace: ns).first.name
   end
 
   test 'after update callback' do
@@ -74,6 +78,7 @@ class CallbacksTest < ActiveSupport::TestCase
     end
     assert @mock_model.update(name: 'This name should make it into datastore')
     assert_equal 'Name changed after update', @mock_model.name
-    assert_equal 'This name should make it into datastore', MockModel.all.first.name
+    ns = @mock_model.namespace
+    assert_equal 'This name should make it into datastore', MockModel.all(namespace: ns).first.name
   end
 end

--- a/test/entity_class_method_extensions.rb
+++ b/test/entity_class_method_extensions.rb
@@ -2,12 +2,12 @@
 # Additional methods added for testing only.
 #
 module EntityClassMethodExtensions
-  def all_test_entities
+  def all_test_entities(namespace: nil)
     query = CloudDatastore.dataset.query(name)
-    CloudDatastore.dataset.run(query)
+    CloudDatastore.dataset.run(query, namespace: namespace)
   end
 
-  def count_test_entities
-    all_test_entities.length
+  def count_test_entities(namespace: nil)
+    all_test_entities(namespace: namespace).length
   end
 end


### PR DESCRIPTION
Enable callers to leverage Cloud Datastore namespaces. e.g.,

```ruby
# Create a new Person under the specified organization
person = Person.new({ name: 'Abby Adams' })
person.namespace = organization_name

# Find a Person under the specified organization
person = Person.find_by(_id: person_id, namespace: organization_name)

# Find all Persons under the specified organization
persons = Person.all(namespace: organization_name)
```

All tests pass (including Rails). Rubocop clean.

Resolves #13.