### PR TITLE
Setup Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: ruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,2 @@
 language: ruby
+cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache:
   bundler: true
   directories:
     - "$HOME/google-cloud-sdk/"
-script:
+before_install:
   - gcloud version || true
   - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf $HOME/google-cloud-sdk; export CLOUDSDK_CORE_DISABLE_PROMPTS=1; curl https://sdk.cloud.google.com | bash; fi
   # Add gcloud to $PATH:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,5 @@ before_install:
   - export PATH="$HOME/google-cloud-sdk/platform/cloud-datastore-emulator:$PATH"
   - cloud_datastore_emulator create tmp/local_datastore
   - cloud_datastore_emulator start --port=8180 tmp/local_datastore &
+  # Await emulator listening on port 8180 before continuing:
+  - while [ ! nc -vzw1 localhost 8180 2> /dev/null ]; do echo -n .; sleep 0.1; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,15 @@
 language: ruby
-cache: bundler
+cache:
+  - bundler
+  directories:
+    - "$HOME/google-cloud-sdk/"
+script:
+  - gcloud version || true
+  - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf $HOME/google-cloud-sdk; export CLOUDSDK_CORE_DISABLE_PROMPTS=1; curl https://sdk.cloud.google.com | bash; fi
+  # Add gcloud to $PATH:
+  - source /home/travis/google-cloud-sdk/path.bash.inc
+  - gcloud version
+  - gcloud components install cloud-datastore-emulator
+  - export PATH="$HOME/google-cloud-sdk/platform/cloud-datastore-emulator:$PATH"
+  - cloud_datastore_emulator create tmp/local_datastore
+  - cloud_datastore_emulator start --port=8180 tmp/local_datastore &

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 cache:
-  - bundler
+  bundler: true
   directories:
     - "$HOME/google-cloud-sdk/"
 script:


### PR DESCRIPTION
Without changing the current way everything is run, this gets to a green build on Travis CI. Fixes #17, though without using docker - the idea of introducing a docker setup was mostly to make contributing easier, but CI goes a long way towards that.

Ran this on Travis CI, worked great: https://travis-ci.org/rud/activemodel-datastore