### PR TITLE
should not override DATASTORE related environment variables if already defined

### DIFF
--- a/lib/active_model/datastore/connection.rb
+++ b/lib/active_model/datastore/connection.rb
@@ -14,14 +14,14 @@
 module CloudDatastore
   if defined?(Rails) == 'constant'
     if Rails.env.development?
-      ENV['DATASTORE_EMULATOR_HOST'] = 'localhost:8180'
-      ENV['GCLOUD_PROJECT'] = 'local-datastore'
+      ENV['DATASTORE_EMULATOR_HOST'] ||= 'localhost:8180'
+      ENV['GCLOUD_PROJECT'] ||= 'local-datastore'
     elsif Rails.env.test?
-      ENV['DATASTORE_EMULATOR_HOST'] = 'localhost:8181'
-      ENV['GCLOUD_PROJECT'] = 'test-datastore'
+      ENV['DATASTORE_EMULATOR_HOST'] ||= 'localhost:8181'
+      ENV['GCLOUD_PROJECT'] ||= 'test-datastore'
     elsif ENV['SERVICE_ACCOUNT_PRIVATE_KEY'].present? &&
           ENV['SERVICE_ACCOUNT_CLIENT_EMAIL'].present?
-      ENV['GCLOUD_KEYFILE_JSON'] = '{"private_key": "' + ENV['SERVICE_ACCOUNT_PRIVATE_KEY'] + '",
+      ENV['GCLOUD_KEYFILE_JSON'] ||= '{"private_key": "' + ENV['SERVICE_ACCOUNT_PRIVATE_KEY'] + '",
       "client_email": "' + ENV['SERVICE_ACCOUNT_CLIENT_EMAIL'] + '"}'
     end
   end


### PR DESCRIPTION
# motivation

I want to use custom emulator instance in Docker environment. (e.g. running datastore emulator under Docker container).

Original implement cannot do so even run container with given correct environment variables such as `DATASTORE_EMULATOR_HOST=db:8432`.

# resolution

does not override if target environment variable already defined.