### PR TITLE
sort by multiple columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ users = User.all(ancestor: parent_key, where: ['name', '=', 'Bryce'])
 
 users = User.all(where: [['name', '=', 'Ian'], ['enabled', '=', true]])
 
+users = User.all(sort: {name: :asc, created_at: :desc})
+
 users, cursor = User.all(limit: 7)
 
 # @param [Hash] options The options to construct the query with.
@@ -252,8 +254,13 @@ users, cursor = User.all(limit: 7)
 # @option options [Google::Cloud::Datastore::Key] :ancestor Filter for inherited results.
 # @option options [String] :cursor Sets the cursor to start the results at.
 # @option options [Integer] :limit Sets a limit to the number of results to be returned.
-# @option options [String] :order Sort the results by property name.
-# @option options [String] :desc_order Sort the results by descending property name.
+# @option options [Array, Hash] :sort Sort the results in one of these formats
+#   [:name, :asc]
+#   [ [:name, :asc], [:created_at, :desc] ]
+#   { name: :asc, created_at: :desc }
+#   { name: 1, created_at: -1 }
+# @option options [String] :order Sort the results by property name. (deprecated)
+# @option options [String] :desc_order Sort the results by descending property name. (deprecated)
 # @option options [Array] :select Retrieve only select properties from the matched entities.
 # @option options [Array] :where Adds a property filter of arrays in the format[name, operator, value].
 ```

--- a/lib/active_model/datastore.rb
+++ b/lib/active_model/datastore.rb
@@ -386,8 +386,9 @@ module ActiveModel::Datastore
     #   [ [:name, :asc], [:created_at, :desc] ]
     #   { name: :asc, created_at: :desc }
     #   { name: 1, created_at: -1 }
-    # @option options [String] :order Sort the results by property name. (deprecated)
-    # @option options [String] :desc_order Sort the results by descending property name. (deprecated)
+    # @option options [String] :order @deprecated Sort the results by property name.
+    # @option options [String] :desc_order @deprecated Sort the results by descending property name.
+    #
     # @option options [Array] :select Retrieve only select properties from the matched entities.
     # @option options [Array] :where Adds a property filter of arrays in the format
     #   [name, operator, value].
@@ -455,14 +456,15 @@ module ActiveModel::Datastore
     def query_sort(query, options)
       query.order(options[:order]) if options[:order]
       query.order(options[:desc_order], :desc) if options[:desc_order]
-      if options[:sort].is_a?(Array)
+      case options[:sort]
+      when Array
         options[:sort] = [options[:sort]] unless options[:sort].first.is_a?(Array)
         options[:sort].each do |condition|
-          query.order(condition[0].to_s, [:desc, 'desc', -1].include?(condition[1]) ? :desc : :asc)
+          query.order(condition[0].to_s, parse_query_direction(condition[1]))
         end
-      elsif options[:sort].is_a?(Hash)
+      when Hash
         options[:sort].each_pair do |field, way|
-          query.order(field.to_s, [:desc, 'desc', -1].include?(way) ? :desc : :asc)
+          query.order(field.to_s, parse_query_direction(way))
         end
       end
     end
@@ -484,6 +486,13 @@ module ActiveModel::Datastore
         end
       end
       query
+    end
+
+    #
+    # parse convert query direction words
+    #
+    def parse_query_direction(word)
+      [:desc, 'desc', -1].include?(word) ? :desc : :asc
     end
 
     ##

--- a/test/cases/datastore_test.rb
+++ b/test/cases/datastore_test.rb
@@ -403,7 +403,7 @@ class ActiveModel::DatastoreTest < ActiveSupport::TestCase
     assert_equal parent_string_key.kind, key.kind
     assert_equal key.id_type, :name
     assert_equal parent_string_key.name, key.name
-    grpc = MockModel.build_query(sort: {name: :asc, timestamp: :desc}).to_grpc
+    grpc = MockModel.build_query(sort: { name: :asc, timestamp: :desc }).to_grpc
     assert_equal grpc.order.count, 2
     assert_equal grpc.order[0].property.name, 'name'
     assert_equal grpc.order[0].direction, :ASCENDING

--- a/test/cases/datastore_test.rb
+++ b/test/cases/datastore_test.rb
@@ -403,5 +403,21 @@ class ActiveModel::DatastoreTest < ActiveSupport::TestCase
     assert_equal parent_string_key.kind, key.kind
     assert_equal key.id_type, :name
     assert_equal parent_string_key.name, key.name
+    grpc = MockModel.build_query(sort: {name: :asc, timestamp: :desc}).to_grpc
+    assert_equal grpc.order.count, 2
+    assert_equal grpc.order[0].property.name, 'name'
+    assert_equal grpc.order[0].direction, :ASCENDING
+    assert_equal grpc.order[1].property.name, 'timestamp'
+    assert_equal grpc.order[1].direction, :DESCENDING
+    grpc = MockModel.build_query(sort: [:timestamp, -1]).to_grpc
+    assert_equal grpc.order.count, 1
+    assert_equal grpc.order.first.property.name, 'timestamp'
+    assert_equal grpc.order.first.direction, :DESCENDING
+    grpc = MockModel.build_query(sort: [[:name, 1], [:timestamp, -1]]).to_grpc
+    assert_equal grpc.order.count, 2
+    assert_equal grpc.order[0].property.name, 'name'
+    assert_equal grpc.order[0].direction, :ASCENDING
+    assert_equal grpc.order[1].property.name, 'timestamp'
+    assert_equal grpc.order[1].direction, :DESCENDING
   end
 end


### PR DESCRIPTION
# Motivation

need complex sorting feature, such as `name: :asc, timestamp: :desc`

# Resolution

I've created new option `sort` for query. `order` and `order_desc` should be no longer using.
In this option, you can use many flavor of syntax like [MongoDB](https://docs.mongodb.com/manual/reference/method/cursor.sort/).

```ruby
# Array
User.all(sort: [:name, :desc])

# Array in Array
User.all(sort: [[:name, :desc], [:created_at, :asc]])

# Hash
User.all(sort: { name: :desc, created_at: :asc })

# 1 / -1 instead of `:desc` / `:asc`
User.all(sort: { name: -1, created_at: 1 })
```

