### PR TITLE
add :distinct_on option to Model#all

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ users, cursor = User.all(limit: 7)
 # @option options [String] :order Sort the results by property name.
 # @option options [String] :desc_order Sort the results by descending property name.
 # @option options [Array] :select Retrieve only select properties from the matched entities.
+# @option options [Array] :distinct_on Group results by a list of properties.
 # @option options [Array] :where Adds a property filter of arrays in the format[name, operator, value].
 ```
 

--- a/lib/active_model/datastore.rb
+++ b/lib/active_model/datastore.rb
@@ -273,6 +273,7 @@ module ActiveModel::Datastore
     # @option options [String] :order Sort the results by property name.
     # @option options [String] :desc_order Sort the results by descending property name.
     # @option options [Array] :select Retrieve only select properties from the matched entities.
+    # @option options [Array] :distinct_on Group results by a list of properties.
     # @option options [Array] :where Adds a property filter of arrays in the format
     #   [name, operator, value].
     #
@@ -383,6 +384,7 @@ module ActiveModel::Datastore
     # @option options [String] :order Sort the results by property name.
     # @option options [String] :desc_order Sort the results by descending property name.
     # @option options [Array] :select Retrieve only select properties from the matched entities.
+    # @option options [Array] :distinct_on Group results by a list of properties.
     # @option options [Array] :where Adds a property filter of arrays in the format
     #   [name, operator, value].
     #
@@ -440,6 +442,7 @@ module ActiveModel::Datastore
       query.limit(options[:limit]) if options[:limit]
       query_sort(query, options)
       query.select(*options[:select]) if options[:select]
+      query.distinct_on(*options[:distinct_on]) if options[:distinct_on]
       query_property_filter(query, options)
     end
 

--- a/test/cases/datastore_test.rb
+++ b/test/cases/datastore_test.rb
@@ -385,6 +385,14 @@ class ActiveModel::DatastoreTest < ActiveSupport::TestCase
     grpc = MockModel.build_query(select: %w[name role]).to_grpc
     refute_nil grpc.projection
     assert_equal 2, grpc.projection.count
+    grpc = MockModel.build_query(distinct_on: 'name').to_grpc
+    refute_nil grpc.distinct_on
+    assert_equal 1, grpc.distinct_on.count
+    assert_equal 'name', grpc.distinct_on.first.name
+    grpc = MockModel.build_query(distinct_on: %w[name role]).to_grpc
+    refute_nil grpc.distinct_on
+    assert_equal 2, grpc.distinct_on.count
+    assert_equal 'role', grpc.distinct_on.last.name
     grpc = MockModel.build_query(cursor: 'a_cursor').to_grpc
     refute_nil grpc.start_cursor
     parent_int_key = CloudDatastore.dataset.key('Parent', MOCK_PARENT_ID)


### PR DESCRIPTION
# Motivation

I want to use [DISTINCT ON](https://cloud.google.com/datastore/docs/concepts/queries?hl=en#projection_queries) query.

# Resolution

add `:distinct_on` option to query builder