### PR TITLE
Allow string-literal as key path

### DIFF
--- a/lib/active_model/datastore.rb
+++ b/lib/active_model/datastore.rb
@@ -215,7 +215,7 @@ module ActiveModel::Datastore
     # A default parent key for specifying an ancestor path and creating an entity group.
     #
     def parent_key(parent_id)
-      CloudDatastore.dataset.key('Parent' + name, parent_id.to_i)
+      CloudDatastore.dataset.key('Parent' + name, parent_id)
     end
 
     ##
@@ -310,7 +310,7 @@ module ActiveModel::Datastore
     #
     def find(*ids, parent: nil)
       expects_array = ids.first.is_a?(Array)
-      ids = ids.flatten.compact.uniq.map(&:to_i)
+      ids = ids.flatten.compact.uniq
 
       case ids.size
       when 0


### PR DESCRIPTION
[GQL grammer](https://cloud.google.com/datastore/docs/reference/gql_reference) defines key-path-element as `integer-literal` or `string-literal`.

Reference: https://cloud.google.com/datastore/docs/reference/data/rest/v1/Key